### PR TITLE
Fix terraform version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ http://www.slideshare.net/mumoshu/autoscaled-concourse-ci-on-aws-wo-bosh
 
 ## Recommended Usage: Using `concourse-aws` binary
 
-1. Install [packer](https://github.com/mitchellh/packer) and [terraform (0.10.7+)](https://github.com/hashicorp/terraform)
+1. Install [packer](https://github.com/mitchellh/packer) and [terraform (0.11.7+)](https://github.com/hashicorp/terraform)
   
 2. Create 1 VPC and 2 subnets in it
 


### PR DESCRIPTION
`terraform init` output specifies that `>=0.11.7` is specified by the configuration of this repo; bumping version in the README to reflect that